### PR TITLE
🐛 BaseEntity createdAt,updatedAt 필드가 persist시 자동 세팅되지 않는 문제

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/config/JpaConfig.java
+++ b/src/main/java/knu/team1/be/boost/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package knu.team1.be.boost.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
+++ b/src/main/java/knu/team1/be/boost/common/entity/BaseEntity.java
@@ -1,6 +1,7 @@
 package knu.team1.be.boost.common.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,13 +12,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @Id
@@ -25,11 +28,11 @@ public abstract class BaseEntity {
     @Column(name = "id", nullable = false, updatable = false)
     private UUID id;
 
-    @CreationTimestamp
+    @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @UpdateTimestamp
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- flush 이전에 DTO 반환 시 즉, persist 상태에서 반환시 createdAt/updatedAt 값이 null로 내려오는 문제 수정하였습니다.
- save() 직후에 DTO로 변환해도 값이 항상 세팅되어 내려오도록 설정 즉, 서비스 로직에서 불필요한 flush 처리를 최소화하도록 하였습니다.

### ✨ 작업 내용
- `@CreationTimestamp`, `@UpdateTimestamp` 제거
- `@EnableJpaAuditing` Config 파일 설정
- `@EntityListeners(AuditingEntityListener.class)` 리스너를 통해 persist 직전에 필드 값 자동 세팅

### #️⃣ 연관 이슈
- Close #40 