### PR TITLE
🐛 프로젝트 삭제 시 멤버십이 삭제되지 않는 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/project/service/ProjectService.java
+++ b/src/main/java/knu/team1/be/boost/project/service/ProjectService.java
@@ -107,7 +107,7 @@ public class ProjectService {
             ));
 
         accessPolicy.ensureProjectOwner(projectId, memberId);
-        projectMembershipRepository.deleteAllByProjectId(projectId);
+        projectMembershipRepository.softDeleteAllByProjectId(projectId);
         projectRepository.delete(project);
     }
 }

--- a/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import knu.team1.be.boost.projectMembership.entity.ProjectMembership;
 import knu.team1.be.boost.projectMembership.entity.ProjectRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -34,5 +35,7 @@ public interface ProjectMembershipRepository extends JpaRepository<ProjectMember
 
     List<ProjectMembership> findAllByProjectId(UUID projectId);
 
-    void deleteAllByProjectId(UUID projectId);
+    @Modifying
+    @Query("UPDATE ProjectMembership pm SET pm.deleted = true, pm.deletedAt = CURRENT_TIMESTAMP WHERE pm.project.id = :projectId")
+    void softDeleteAllByProjectId(@Param("projectId") UUID projectId);
 }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 삭제 시 멤버십이 삭제되지 않는 버그를 수정했습니다.

### ✨ 작업 내용
- 프로젝트 삭제 시 해당 프로젝트에 속한 모든 멤버십을 삭제하도록 하여 버그를 수정하였습니다.

### #️⃣ 연관 이슈
- Close #90 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a project now also soft-removes all associated member relationships to prevent leftover memberships and access.
  * Ensures dashboards, member lists, and permission checks reflect removal immediately, avoiding stale data or inconsistencies.
  * Reduces confusion from lingering notifications or counts tied to deleted projects.
  * Improves overall data integrity and user experience when managing project lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->