### PR TITLE
🐛 프로젝트 참여 API URI에 projectId 제거

### DIFF
--- a/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipApi.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipApi.java
@@ -20,14 +20,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "ProjectMembership", description = "Project 참여/떠나기 관련 API")
-@RequestMapping("/api/projects/{projectId}")
 @SecurityRequirement(name = "bearerAuth")
 public interface ProjectMembershipApi {
 
-    @PostMapping("/join-code")
+    @PostMapping("/api/projects/{projectId}/join-code")
     @Operation(
         summary = "프로젝트 참여 코드 생성",
         description = "새 프로젝트 참여 코드를 생성합니다. 기존 코드는 만료됩니다. "
@@ -50,7 +48,7 @@ public interface ProjectMembershipApi {
         @AuthenticationPrincipal UserPrincipalDto user
     );
 
-    @GetMapping("/join-code")
+    @GetMapping("/api/projects/{projectId}/join-code")
     @Operation(
         summary = "프로젝트 참여 코드 조회",
         description = "유효한 프로젝트 참여 코드를 조회합니다. "
@@ -73,7 +71,7 @@ public interface ProjectMembershipApi {
         @AuthenticationPrincipal UserPrincipalDto user
     );
 
-    @PostMapping("/join")
+    @PostMapping("/api/projects/join")
     @Operation(summary = "프로젝트 참여", description = "프로젝트에 참여합니다.")
     @ApiResponses(value = {
         @ApiResponse(
@@ -89,12 +87,11 @@ public interface ProjectMembershipApi {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     ResponseEntity<ProjectJoinResponseDto> joinProject(
-        @PathVariable UUID projectId,
         @AuthenticationPrincipal UserPrincipalDto user,
         @Valid @RequestBody ProjectJoinRequestDto projectJoinRequestDto
     );
 
-    @DeleteMapping("/leave")
+    @DeleteMapping("/api/projects/{projectId}/leave")
     @Operation(summary = "프로젝트 나가기", description = "프로젝트에서 나갑니다.")
     @ApiResponses(value = {
         @ApiResponse(

--- a/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipController.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipController.java
@@ -40,7 +40,6 @@ public class ProjectMembershipController implements ProjectMembershipApi {
 
     @Override
     public ResponseEntity<ProjectJoinResponseDto> joinProject(
-        @PathVariable UUID projectId,
         @AuthenticationPrincipal UserPrincipalDto user,
         @RequestBody ProjectJoinRequestDto requestDto
     ) {


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 참여 API URI에 projectId 제거

### ✨ 작업 내용
- 프로젝트 참여 API의 path parameter에 불필요한 projectId 필드를 제거하였음.

### #️⃣ 연관 이슈
- Close #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 프로젝트 멤버십 API 엔드포인트 경로 구조를 재정렬했습니다. 기존 클래스 레벨 매핑에서 메서드 레벨 매핑으로 변경하여 API 일관성을 개선했습니다. 프로젝트 조인 엔드포인트 처리 방식을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->