### PR TITLE
🐛프로젝트 소유자가 프로젝트를 나갈 수 있는 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/exception/ErrorCode.java
+++ b/src/main/java/knu/team1/be/boost/common/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
         "해당 프로젝트에 참여하지 않은 멤버입니다."),
     PROJECT_MEMBER_ONLY(HttpStatus.FORBIDDEN, "Project member only", "프로젝트 멤버만 사용할 수 있습니다."),
     PROJECT_OWNER_ONLY(HttpStatus.FORBIDDEN, "Project owner only", "프로젝트 소유자만 수행할 수 있습니다."),
+    PROJECT_OWNER_CANNOT_LEAVE(HttpStatus.FORBIDDEN, "Project owner cannot leave",
+        "프로젝트 소유자는 프로젝트를 나갈 수 없습니다."),
 
     // Project Join Code 관련
     EXPIRED_JOIN_CODE(HttpStatus.BAD_REQUEST, "Expired join code", "만료된 참가 코드입니다."),

--- a/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipApi.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipApi.java
@@ -92,7 +92,8 @@ public interface ProjectMembershipApi {
     );
 
     @DeleteMapping("/api/projects/{projectId}/leave")
-    @Operation(summary = "프로젝트 나가기", description = "프로젝트에서 나갑니다.")
+    @Operation(summary = "프로젝트 나가기", description = "프로젝트에서 나갑니다. "
+        + "프로젝트 owner는 프로젝트를 나갈 수 없습니다.")
     @ApiResponses(value = {
         @ApiResponse(
             responseCode = "204",
@@ -101,7 +102,7 @@ public interface ProjectMembershipApi {
         ),
         @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
         @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
-        @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+        @ApiResponse(responseCode = "403", description = "권한 없음 (프로젝트 owner는 나갈 수 없음)", content = @Content),
         @ApiResponse(responseCode = "404", description = "프로젝트 없음", content = @Content),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })

--- a/src/main/java/knu/team1/be/boost/projectMembership/service/ProjectParticipantService.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/service/ProjectParticipantService.java
@@ -98,6 +98,14 @@ class ProjectParticipantService {
                 "projectId: " + projectId + ", memberId: " + memberId
             ));
 
+        // 프로젝트 소유자는 프로젝트를 나갈 수 없음
+        if (projectMembership.getRole() == ProjectRole.OWNER) {
+            throw new BusinessException(
+                ErrorCode.PROJECT_OWNER_CANNOT_LEAVE,
+                "projectId: " + projectId + ", memberId: " + memberId
+            );
+        }
+
         projectMembershipRepository.delete(projectMembership);
     }
 


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 소유자는 프로젝트를 나갈 수 없도록 예외 처리를 추가하였습니다.

### ✨ 작업 내용
- 프로젝트의 소유자가 프로젝트를 나가는 api를 호출하면 403 forbidden을 반환하게 하였습니다.
- accessPolicy에 ensure 메서드는 공통적으로 처리하는 권한 검증 로직을 포함하므로, 지금같은 경우에만 한 번 사용되는 owner이면 거부하는 로직을 leaveProject에 추가하였습니다.

### #️⃣ 연관 이슈
- Close #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로젝트 소유자의 프로젝트 이탈 방지: 프로젝트 소유자가 이탈을 시도하면 "프로젝트 소유자는 프로젝트를 나갈 수 없습니다"는 오류 메시지와 함께 작업이 차단됩니다. 프로젝트 관리 권한을 유지하면서 프로젝트 무결성을 보호합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->