### PR TITLE
✨프로젝트 응답 DTO에 사용자 역할 추가 및 관련 메서드 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/project/dto/ProjectResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/project/dto/ProjectResponseDto.java
@@ -3,6 +3,7 @@ package knu.team1.be.boost.project.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import knu.team1.be.boost.project.entity.Project;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
 
 public record ProjectResponseDto(
     @Schema(description = "프로젝트 고유 ID", example = "a1b2c3d4-e5f6-7890-1234-567890abcdef")
@@ -12,14 +13,18 @@ public record ProjectResponseDto(
     String name,
 
     @Schema(description = "프로젝트 생성/수정 시 기본으로 설정되는 리뷰어 인원 수", example = "2")
-    Integer defaultReviewerCount
+    Integer defaultReviewerCount,
+
+    @Schema(description = "프로젝트에서 사용자의 역할", example = "MEMBER")
+    ProjectRole role
 ) {
 
-    public static ProjectResponseDto from(Project project) {
+    public static ProjectResponseDto from(Project project, ProjectRole role) {
         return new ProjectResponseDto(
             project.getId(),
             project.getName(),
-            project.getDefaultReviewerCount()
+            project.getDefaultReviewerCount(),
+            role
         );
     }
 

--- a/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
@@ -32,6 +32,7 @@ public interface ProjectMembershipRepository extends JpaRepository<ProjectMember
 
     boolean existsByProjectIdAndMemberIdAndRole(UUID projectId, UUID memberId, ProjectRole role);
 
+    @EntityGraph(attributePaths = {"project"})
     List<ProjectMembership> findAllByMemberId(UUID memberId);
     
     @EntityGraph(attributePaths = {"member"})


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 응답 DTO에 사용자 역할 추가 및 관련 메서드 수정

### ✨ 작업 내용
- 기존 응답 DTO가 role을 같이 반환하도록 수정
- projectMembershipRepository.findByProjectIdAndMemberId 가 project도 같이 한 번에 가져오게 하여 N+1 문제를 해결하였음.

### #️⃣ 연관 이슈
- Close #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 프로젝트 정보 조회 시 사용자의 역할 정보 포함
  * 프로젝트 생성, 조회, 목록 조회 및 업데이트 시 사용자 역할 정보 반영
  * 데이터 조회 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->