### PR TITLE
🐛 댓글 응답 DTO에서 isAnonymous 필드가 서로 뒤바뀐 작성자 값을 넣어주는 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
@@ -40,8 +40,8 @@ public record CommentResponseDto(
         return new CommentResponseDto(
             comment.getId(),
             comment.getIsAnonymous()
-                ? AuthorInfoResponseDto.from(comment.getMember())
-                : AuthorInfoResponseDto.anonymous(comment.getMember()),
+                ? AuthorInfoResponseDto.anonymous(comment.getMember())
+                : AuthorInfoResponseDto.from(comment.getMember()),
             comment.getContent(),
             comment.getPersona(),
             comment.getIsAnonymous(),


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 댓글 응답 DTO에서 isAnonymous 필드가 서로 뒤바뀐 작성자 값을 넣어주는 버그 수정

### ✨ 작업 내용
- 삼항 연산자에서 두 파라미터를 교환하였음.

### #️⃣ 연관 이슈
- Close #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 댓글 작성자 정보 표시 로직이 수정되었습니다. 익명 댓글은 익명으로 표시되고, 공개 댓글에는 작성자 정보가 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->