### PR TITLE
🐛댓글 삭제 SQL 쿼리에서 테이블 이름을 'tasks'에서 'comments'로 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/entity/Comment.java
+++ b/src/main/java/knu/team1/be/boost/comment/entity/Comment.java
@@ -24,7 +24,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SuperBuilder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE tasks SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE comments SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted = false")
 @Table(name = "comments")
 public class Comment extends SoftDeletableEntity {


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 댓글 삭제 SQL 쿼리(@SQLDelete)에서 테이블 이름을 'tasks'에서 'comments'로 수정

### ✨ 작업 내용
- 댓글 삭제 SQL 쿼리(@SQLDelete)에서 테이블 이름을 'tasks'에서 'comments'로 수정하였음.
- 댓글이 삭제되지 않는 버그가 수정되었음.

### #️⃣ 연관 이슈
- Close #120