### PR TITLE
⚡️ 프로젝트 삭제 시 태그 일괄 삭제되도록 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/tag/repository/TagRepository.java
+++ b/src/main/java/knu/team1/be/boost/tag/repository/TagRepository.java
@@ -14,7 +14,7 @@ public interface TagRepository extends JpaRepository<Tag, UUID> {
 
     List<Tag> findAllByProjectId(UUID projectId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query(
         "UPDATE Tag t SET t.deleted = true, t.deletedAt = CURRENT_TIMESTAMP WHERE t.project.id = :projectId"
     )


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 현재 프로젝트를 삭제하면 프로젝트에 속한 태그가 일괄적으로 삭제되지 않고 하나씩 삭제되는 문제를 해결하였음.

### ✨ 작업 내용
- 프로젝트 삭제 시 프로젝트에 속한 태그를 일괄적으로 삭제하는 커스텀 JPA 메서드를 구현하였음.

### #️⃣ 연관 이슈
- Close #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 프로젝트의 태그 삭제 처리 방식 변경: 개별 삭제 대신 해당 프로젝트의 모든 태그를 일괄로 삭제 표시(soft-delete)하고 삭제 시각을 기록하도록 개선하여 데이터 추적성 및 감사 기능 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->