### PR TITLE
✨ 할 일 상세 조회에서 내가 승인 했는지 여부 응답에 포함시키도록 추가

### DIFF
--- a/src/main/java/knu/team1/be/boost/task/dto/TaskDetailResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/task/dto/TaskDetailResponseDto.java
@@ -43,6 +43,9 @@ public record TaskDetailResponseDto(
     @Schema(description = "필요 리뷰어 수", example = "2")
     Integer requiredReviewerCount,
 
+    @Schema(description = "내가 승인했는지 여부", example = "true")
+    Boolean approvedByMe,
+
     @ArraySchema(
         schema = @Schema(implementation = TagResponseDto.class),
         arraySchema = @Schema(description = "태그 목록")
@@ -76,6 +79,7 @@ public record TaskDetailResponseDto(
 
     public static TaskDetailResponseDto from(
         Task task,
+        boolean approvedByMe,
         List<Comment> comments,
         List<File> files,
         List<Member> projectMembers
@@ -89,6 +93,7 @@ public record TaskDetailResponseDto(
             task.getUrgent(),
             task.getApprovers().size(),
             task.getRequiredApprovalsCount(projectMembers),
+            approvedByMe,
             task.getTags().stream()
                 .map(TagResponseDto::from)
                 .collect(Collectors.toList()),

--- a/src/main/java/knu/team1/be/boost/task/service/TaskService.java
+++ b/src/main/java/knu/team1/be/boost/task/service/TaskService.java
@@ -216,6 +216,14 @@ public class TaskService {
 
         accessPolicy.ensureProjectMember(project.getId(), user.id());
 
+        boolean approvedByMe = false;
+        for (Member approver : task.getApprovers()) {
+            if (approver.getId().equals(user.id())) {
+                approvedByMe = true;
+                break;
+            }
+        }
+
         List<Comment> comments = commentRepository.findAllByTaskId(task.getId());
         List<File> files = fileRepository.findAllByTask(task);
         List<Member> projectMembers = projectMembershipRepository.findAllByProjectId(
@@ -224,7 +232,13 @@ public class TaskService {
             .map(ProjectMembership::getMember)
             .toList();
 
-        return TaskDetailResponseDto.from(task, comments, files, projectMembers);
+        return TaskDetailResponseDto.from(
+            task,
+            approvedByMe,
+            comments,
+            files,
+            projectMembers
+        );
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 할 일 상세 조회에서 내가 승인 했는지 여부 응답에 포함시키도록 추가

### ✨ 작업 내용
- TaskDetailResponseDto에 '내가 승인했는지 여부' 필드 추가 및 TaskService에서 승인 여부 찾는 로직 구현
- 프론트에서 내가 승인했는지 여부에 따라서 버튼의 UI가 다르게 표현하기위해서 해당 boolean 값을 포함해서 전달

### #️⃣ 연관 이슈
- Close #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 작업 상세 조회 응답에 사용자 승인 여부 정보가 추가되었습니다
  * 현재 사용자가 해당 작업의 승인자 목록에 포함되어 있는지 여부를 표시하는 필드가 추가됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->