### PR TITLE
🐛 회원 탈퇴 후 재가입 시 500에러 해결

### DIFF
--- a/src/main/java/knu/team1/be/boost/member/repository/MemberRepository.java
+++ b/src/main/java/knu/team1/be/boost/member/repository/MemberRepository.java
@@ -4,11 +4,20 @@ import java.util.Optional;
 import java.util.UUID;
 import knu.team1.be.boost.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
 
     Optional<Member> findByOauthInfoProviderAndOauthInfoProviderId(
         String provider,
         Long providerId
+    );
+
+    @Query(value = "SELECT * FROM members WHERE provider = :provider AND provider_id = :providerId LIMIT 1",
+        nativeQuery = true)
+    Optional<Member> findByOauthInfoProviderAndOauthInfoProviderIdIncludingDeleted(
+        @Param("provider") String provider,
+        @Param("providerId") Long providerId
     );
 }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 회원 탈퇴 후 재가입 시 500에러 발생하는 것을 해결하였음.

### ✨ 작업 내용
- 기존 UniqueConstraint에 의해 동일한 provider 및 provider_id를 가지고 있으면 새로운 튜플을 생성할 수 없으므로, deleted 처리된 튜플을 reactivate하도록 구현하였음.

### #️⃣ 연관 이슈
- Close #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 삭제된 계정으로 다시 로그인할 때 계정이 자동으로 복구됩니다.

* **개선사항**
  * OAuth 인증 프로세스가 개선되어 더욱 안정적인 사용자 경험을 제공합니다.
  * 로그인 및 가입 절차가 통합되어 일관된 인증 흐름을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->