### PR TITLE
🐛 동일한 파일 참조하는 댓글 생성 시 500 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/entity/vo/FileInfo.java
+++ b/src/main/java/knu/team1/be/boost/comment/entity/vo/FileInfo.java
@@ -4,7 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import knu.team1.be.boost.file.entity.File;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FileInfo {
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "file_id")
     private File file;
 


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 동일한 파일 참조하는 댓글 생성 시 500 버그를 수정하였음.

### ✨ 작업 내용
- 댓글에서 File과의 1대1 관계를 다대일 관계로 변경하여 unique 제약조건이 발생하지 않도록 하였음.

### #️⃣ 연관 이슈
- Close #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 파일-첨부 관계 매핑 방식이 내부적으로 조정되었습니다.
* **Chores**
  * 내부 엔티티 매핑 관련 경미한 코드 정리를 수행했습니다.
* **영향**
  * 최종 사용자 관점에서 동작이나 UI에는 변화가 없으며, 안정성 및 유지보수성 개선을 위한 내부 업데이트입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->