### PR TITLE
✨ 댓글 목록 반환 시에 응답에 배경 색상 포함하도록 구현

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/comment/dto/CommentResponseDto.java
@@ -36,6 +36,10 @@ public record CommentResponseDto(
     LocalDateTime updatedAt
 ) {
 
+    private static final String ANONYMOUS_NAME = "익명";
+    private static final String ANONYMOUS_AVATAR = "0000";
+    private static final String ANONYMOUS_BACKGROUND_COLOR = "#99a1af";
+
     public static CommentResponseDto from(Comment comment) {
         return new CommentResponseDto(
             comment.getId(),
@@ -80,9 +84,9 @@ public record CommentResponseDto(
         public static AuthorInfoResponseDto anonymous(Member member) {
             return new AuthorInfoResponseDto(
                 member.getId(),
-                "익명",
-                "0000",
-                "#99a1af"
+                ANONYMOUS_NAME,
+                ANONYMOUS_AVATAR,
+                ANONYMOUS_BACKGROUND_COLOR
             );
         }
     }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- AuthorInfoResponseDto 회원 배경색 필드 추가

### ✨ 작업 내용
- 댓글 목록 반환 시에 응답에 배경 색상 포함하도록 구현
- 익명일 경우 회색(#99a1af) 반환

### #️⃣ 연관 이슈
- Close #170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 작성자 정보에 배경색(backgroundColor) 속성 추가
  * 사용자의 프로필 배경색이 댓글 작성자 정보에 반영
  * 익명 작성자에 대해 기본 배경색이 설정되어 표시됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->