### PR TITLE
🐛 멤버가 탈퇴할 때 참여하고 있는 프로젝트가 유지되는 버그 수정

### DIFF
--- a/src/main/java/knu/team1/be/boost/common/exception/ErrorCode.java
+++ b/src/main/java/knu/team1/be/boost/common/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     // Member 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found", "해당 사용자를 찾을 수 없습니다."),
     MEMBER_ALREADY_JOINED(HttpStatus.CONFLICT, "Member already joined", "이미 참여한 멤버입니다."),
+    MEMBER_HAS_OWNED_PROJECTS(HttpStatus.CONFLICT, "Member has owned projects",
+        "소유한 프로젝트가 있어 탈퇴할 수 없습니다. 프로젝트를 먼저 삭제해주세요."),
 
     // Project 관련
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "Project not found", "해당 프로젝트를 찾을 수 없습니다."),

--- a/src/main/java/knu/team1/be/boost/member/service/MemberService.java
+++ b/src/main/java/knu/team1/be/boost/member/service/MemberService.java
@@ -9,6 +9,7 @@ import knu.team1.be.boost.member.dto.MemberNotificationResponseDto;
 import knu.team1.be.boost.member.dto.MemberResponseDto;
 import knu.team1.be.boost.member.entity.Member;
 import knu.team1.be.boost.member.repository.MemberRepository;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
 import knu.team1.be.boost.projectMembership.repository.ProjectMembershipRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -68,6 +69,18 @@ public class MemberService {
                 ErrorCode.MEMBER_NOT_FOUND,
                 "memberId: " + memberId
             ));
+
+        boolean hasOwnedProjects = projectMembershipRepository.existsByMemberIdAndRole(
+            memberId,
+            ProjectRole.OWNER
+        );
+
+        if (hasOwnedProjects) {
+            throw new BusinessException(
+                ErrorCode.MEMBER_HAS_OWNED_PROJECTS,
+                "memberId: " + memberId
+            );
+        }
 
         projectMembershipRepository.softDeleteAllByMemberId(memberId);
 

--- a/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
+++ b/src/main/java/knu/team1/be/boost/projectMembership/repository/ProjectMembershipRepository.java
@@ -45,4 +45,6 @@ public interface ProjectMembershipRepository extends JpaRepository<ProjectMember
     @Modifying
     @Query("UPDATE ProjectMembership pm SET pm.deleted = true, pm.deletedAt = CURRENT_TIMESTAMP WHERE pm.member.id = :memberId")
     void softDeleteAllByMemberId(@Param("memberId") UUID memberId);
+
+    boolean existsByMemberIdAndRole(UUID memberId, ProjectRole role);
 }


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 멤버가 탈퇴할 때 참여하고 있는 프로젝트가 유지되어 재가입 시 프로젝트가 남아있는 버그를 수정하였음.

### ✨ 작업 내용
- 멤버 탈퇴 시, owner로 있는 프로젝트가 있으면 에러, 없다면 멤버십을 모두 삭제하고 탈퇴가 되도록 구현하였음.

### #️⃣ 연관 이슈
- Close #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **개선사항**
  * 소유한 프로젝트가 있을 경우 계정 탈퇴 제한 - 프로젝트를 먼저 삭제한 후 탈퇴 가능
  * 계정 삭제 시 프로젝트 멤버십 정보가 안전하게 처리됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->