### PR TITLE
✨ 프로젝트 정보를 반환할 때 프로젝트 알림 설정 여부도 포함하도록 변경

### DIFF
--- a/src/main/java/knu/team1/be/boost/project/dto/ProjectResponseDto.java
+++ b/src/main/java/knu/team1/be/boost/project/dto/ProjectResponseDto.java
@@ -16,15 +16,19 @@ public record ProjectResponseDto(
     Integer defaultReviewerCount,
 
     @Schema(description = "프로젝트에서 사용자의 역할", example = "MEMBER")
-    ProjectRole role
+    ProjectRole role,
+
+    @Schema(description = "프로젝트 알림 허용 여부", example = "true")
+    boolean isNotificationEnabled
 ) {
 
-    public static ProjectResponseDto from(Project project, ProjectRole role) {
+    public static ProjectResponseDto from(Project project, ProjectRole role, boolean isNotificationEnabled) {
         return new ProjectResponseDto(
             project.getId(),
             project.getName(),
             project.getDefaultReviewerCount(),
-            role
+            role,
+            isNotificationEnabled
         );
     }
 

--- a/src/main/java/knu/team1/be/boost/project/service/ProjectService.java
+++ b/src/main/java/knu/team1/be/boost/project/service/ProjectService.java
@@ -53,7 +53,7 @@ public class ProjectService {
             ProjectRole.OWNER
         );
         projectMembershipRepository.save(projectMembership);
-        return ProjectResponseDto.from(savedProject, ProjectRole.OWNER);
+        return ProjectResponseDto.from(savedProject, ProjectRole.OWNER, projectMembership.isNotificationEnabled());
     }
 
     public ProjectResponseDto getProject(UUID projectId, UUID memberId) {
@@ -73,7 +73,7 @@ public class ProjectService {
                 "projectId: " + projectId + ", memberId: " + memberId
             ));
 
-        return ProjectResponseDto.from(project, membership.getRole());
+        return ProjectResponseDto.from(project, membership.getRole(), membership.isNotificationEnabled());
     }
 
     public List<ProjectResponseDto> getMyProjects(UUID memberId) {
@@ -84,7 +84,8 @@ public class ProjectService {
         return projectMemberships.stream()
             .map(membership -> ProjectResponseDto.from(
                 membership.getProject(),
-                membership.getRole()
+                membership.getRole(),
+                membership.isNotificationEnabled()
             ))
             .toList();
     }
@@ -106,7 +107,14 @@ public class ProjectService {
 
         oldProject.updateProject(requestDto.name(), requestDto.defaultReviewerCount());
 
-        return ProjectResponseDto.from(oldProject, ProjectRole.OWNER);
+        ProjectMembership membership = projectMembershipRepository.findByProjectIdAndMemberId(
+                projectId, memberId)
+            .orElseThrow(() -> new BusinessException(
+                ErrorCode.PROJECT_MEMBER_NOT_FOUND,
+                "projectId: " + projectId + ", memberId: " + memberId
+            ));
+
+        return ProjectResponseDto.from(oldProject, ProjectRole.OWNER, membership.isNotificationEnabled());
     }
 
     @Transactional


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 정보를 반환할 때 프로젝트 알림 설정 여부도 포함하도록 변경하였음.

### ✨ 작업 내용
- ProjectResponseDto에 알림 설정 여부를 포함하여 구현하였음.

### #️⃣ 연관 이슈
- Close #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로젝트 응답에 알림 활성화 상태 정보가 포함되도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->