### PR TITLE
🐛 댓글을 조회할 때 생성일 기준으로 정렬하도록 변경

### DIFF
--- a/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
+++ b/src/main/java/knu/team1/be/boost/comment/repository/CommentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
-    List<Comment> findAllByTaskId(UUID taskId);
+    List<Comment> findAllByTaskIdOrderByCreatedAtAsc(UUID taskId);
 
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.task.id = :taskId")
     long countByTaskId(@Param("taskId") UUID taskId);

--- a/src/main/java/knu/team1/be/boost/comment/service/CommentService.java
+++ b/src/main/java/knu/team1/be/boost/comment/service/CommentService.java
@@ -42,7 +42,7 @@ public class CommentService {
     ) {
         accessPolicy.ensureProjectMember(projectId, memberId);
 
-        List<Comment> comments = commentRepository.findAllByTaskId(taskId);
+        List<Comment> comments = commentRepository.findAllByTaskIdOrderByCreatedAtAsc(taskId);
         return comments.stream()
             .map(CommentResponseDto::from)
             .collect(Collectors.toList());


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 댓글을 조회할 때 생성일 기준으로 정렬하도록 변경

### ✨ 작업 내용
- CommentRepository에서 taskId로 댓글을 조회할 때 생성일 기준으로 정렬하도록 변경하였음.

### #️⃣ 연관 이슈
- Close #189 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 댓글이 작성된 시간 순서대로 오름차순으로 정렬되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->