### PR TITLE
♻️ Task 엔티티에 인덱스 추가

### DIFF
--- a/src/main/java/knu/team1/be/boost/task/entity/Task.java
+++ b/src/main/java/knu/team1/be/boost/task/entity/Task.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
@@ -34,7 +35,14 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-@Table(name = "tasks")
+@Table(
+    name = "tasks",
+    indexes = {
+        @Index(name = "idx_tasks_project_status_created", columnList = "project_id, status, created_at, id"),
+        @Index(name = "idx_tasks_project_status_duedate", columnList = "project_id, status, due_date, id"),
+        @Index(name = "idx_tasks_duedate_status", columnList = "due_date, status")
+    }
+)
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE tasks SET deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ? AND version = ?")
@@ -84,7 +92,8 @@ public class Task extends SoftDeletableEntity {
     @JoinTable(
         name = "task_assignees",
         joinColumns = @JoinColumn(name = "task_id"),
-        inverseJoinColumns = @JoinColumn(name = "member_id")
+        inverseJoinColumns = @JoinColumn(name = "member_id"),
+        indexes = @Index(name = "idx_task_assignees_member_task", columnList = "member_id, task_id")
     )
     @Builder.Default
     private Set<Member> assignees = new LinkedHashSet<>();


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- Task 조회 성능 개선을 위한 데이터베이스 인덱스 추가

### ✨ 작업 내용
#### 추가된 인덱스:
- tasks 테이블 복합 인덱스 3개
  - idx_tasks_project_status_created: 프로젝트+상태 필터링 및 생성일 정렬
  - idx_tasks_project_status_duedate: 프로젝트+상태 필터링 및 마감일 정렬
  - idx_tasks_duedate_status: 마감일 알림 조회
- task_assignees 조인 테이블 인덱스 1개
  - idx_task_assignees_member_task: 멤버별 태스크 조회
 
#### 기대 성능 개선:
- 프로젝트/상태별 태스크 목록 조회 시 풀스캔 → 인덱스 스캔으로 전환
- "내 태스크" 조회 시 조인 테이블 풀스캔 제거 (member_id 기반 직접 접근)
- 태스크 정렬(생성일/마감일) 시 인메모리 정렬 → 인덱스 정렬 활용
- 특히 태스크가 많은 프로젝트에서 조회 속도 대폭 개선 예상

### #️⃣ 연관 이슈
- Close #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **최적화**
  * 작업 조회 기능의 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->