### PR TITLE
✅ BoostingScore 관련 단위 테스트 코드 추가

### DIFF
--- a/src/test/java/knu/team1/be/boost/boostingScore/controller/BoostingScoreControllerTest.java
+++ b/src/test/java/knu/team1/be/boost/boostingScore/controller/BoostingScoreControllerTest.java
@@ -1,0 +1,234 @@
+package knu.team1.be.boost.boostingScore.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.boostingScore.dto.BoostingScoreResponseDto;
+import knu.team1.be.boost.boostingScore.service.BoostingScoreService;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.security.filter.JwtAuthFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@WebMvcTest(
+    controllers = BoostingScoreController.class,
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        OAuth2ClientAutoConfiguration.class
+    },
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JwtAuthFilter.class
+    )
+)
+class BoostingScoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private BoostingScoreService boostingScoreService;
+
+    private static final UUID testUserId = TestSecurityConfig.testUserPrincipal.id();
+
+    private final UUID projectId = UUID.randomUUID();
+    private final UUID memberId = UUID.randomUUID();
+
+    @TestConfiguration
+    static class TestSecurityConfig implements WebMvcConfigurer {
+
+        static UserPrincipalDto testUserPrincipal = new UserPrincipalDto(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "테스트유저",
+            "1111"
+        );
+
+        @Bean
+        public HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver() {
+            return new HandlerMethodArgumentResolver() {
+                @Override
+                public boolean supportsParameter(MethodParameter parameter) {
+                    return parameter.getParameterType().equals(UserPrincipalDto.class) &&
+                        parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+                }
+
+                @Override
+                public Object resolveArgument(
+                    MethodParameter parameter,
+                    ModelAndViewContainer mavContainer,
+                    NativeWebRequest webRequest,
+                    WebDataBinderFactory binderFactory
+                ) {
+                    return testUserPrincipal;
+                }
+            };
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(authenticationPrincipalArgumentResolver());
+        }
+    }
+
+    private BoostingScoreResponseDto createMockResponseDto(UUID memberId, Integer rank) {
+        return BoostingScoreResponseDto.builder()
+            .memberId(memberId)
+            .totalScore(25)
+            .rank(rank)
+            .calculatedAt(LocalDateTime.now())
+            .build();
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 성공")
+    void getBoostingScores_Success() throws Exception {
+        // given
+        List<BoostingScoreResponseDto> scores = List.of(
+            createMockResponseDto(memberId, 1),
+            createMockResponseDto(UUID.randomUUID(), 2),
+            createMockResponseDto(UUID.randomUUID(), 3)
+        );
+
+        when(boostingScoreService.getProjectBoostingScores(projectId, testUserId))
+            .thenReturn(scores);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(3))
+            .andExpect(jsonPath("$[0].rank").value(1))
+            .andExpect(jsonPath("$[0].totalScore").value(25))
+            .andExpect(jsonPath("$[1].rank").value(2))
+            .andExpect(jsonPath("$[2].rank").value(3))
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 성공 - 빈 리스트")
+    void getBoostingScores_Success_EmptyList() throws Exception {
+        // given
+        when(boostingScoreService.getProjectBoostingScores(projectId, testUserId))
+            .thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(0))
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 실패 - 프로젝트 멤버 아님")
+    void getBoostingScores_Fail_NotProjectMember() throws Exception {
+        // given
+        when(boostingScoreService.getProjectBoostingScores(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 실패 - 프로젝트 없음")
+    void getBoostingScores_Fail_ProjectNotFound() throws Exception {
+        // given
+        when(boostingScoreService.getProjectBoostingScores(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 실패 - 점수 계산 실패")
+    void getBoostingScores_Fail_CalculationFailed() throws Exception {
+        // given
+        when(boostingScoreService.getProjectBoostingScores(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.BOOSTING_SCORE_CALCULATION_FAILED));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 - 단일 멤버")
+    void getBoostingScores_SingleMember() throws Exception {
+        // given
+        List<BoostingScoreResponseDto> scores = List.of(
+            createMockResponseDto(memberId, 1)
+        );
+
+        when(boostingScoreService.getProjectBoostingScores(projectId, testUserId))
+            .thenReturn(scores);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/boosting-scores", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(1))
+            .andExpect(jsonPath("$[0].rank").value(1))
+            .andExpect(jsonPath("$[0].totalScore").value(25))
+            .andExpect(jsonPath("$[0].memberId").value(memberId.toString()))
+            .andDo(print());
+
+        verify(boostingScoreService, times(1))
+            .getProjectBoostingScores(eq(projectId), eq(testUserId));
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/boostingScore/scheduler/BoostingScoreSchedulerTest.java
+++ b/src/test/java/knu/team1/be/boost/boostingScore/scheduler/BoostingScoreSchedulerTest.java
@@ -1,0 +1,224 @@
+package knu.team1.be.boost.boostingScore.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.boostingScore.service.BoostingScoreService;
+import knu.team1.be.boost.project.entity.Project;
+import knu.team1.be.boost.project.repository.ProjectRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoostingScoreSchedulerTest {
+
+    @InjectMocks
+    private BoostingScoreScheduler boostingScoreScheduler;
+
+    @Mock
+    private BoostingScoreService boostingScoreService;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Test
+    @DisplayName("스케줄러 실행 성공 - 모든 프로젝트 점수 계산")
+    void calculateAllBoostingScores_Success() {
+        // given
+        Project project1 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트1")
+            .build();
+
+        Project project2 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트2")
+            .build();
+
+        List<Project> projects = List.of(project1, project2);
+
+        when(projectRepository.findAll()).thenReturn(projects);
+        doNothing().when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, times(2))
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project1.getId());
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project2.getId());
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 성공 - 프로젝트 없음")
+    void calculateAllBoostingScores_NoProjects() {
+        // given
+        when(projectRepository.findAll()).thenReturn(List.of());
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, never())
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 - 일부 프로젝트 실패해도 계속 진행")
+    void calculateAllBoostingScores_PartialFailure() {
+        // given
+        Project project1 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트1")
+            .build();
+
+        Project project2 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트2")
+            .build();
+
+        Project project3 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트3")
+            .build();
+
+        List<Project> projects = List.of(project1, project2, project3);
+
+        when(projectRepository.findAll()).thenReturn(projects);
+        doNothing().when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project1.getId());
+        doThrow(new RuntimeException("점수 계산 실패"))
+            .when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project2.getId());
+        doNothing().when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project3.getId());
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, times(3))
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project1.getId());
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project2.getId());
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project3.getId());
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 - ProjectRepository에서 예외 발생")
+    void calculateAllBoostingScores_RepositoryException() {
+        // given
+        when(projectRepository.findAll())
+            .thenThrow(new RuntimeException("DB 연결 오류"));
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, never())
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 - 모든 프로젝트 계산 실패")
+    void calculateAllBoostingScores_AllFailed() {
+        // given
+        Project project1 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트1")
+            .build();
+
+        Project project2 = Project.builder()
+            .id(UUID.randomUUID())
+            .name("프로젝트2")
+            .build();
+
+        List<Project> projects = List.of(project1, project2);
+
+        when(projectRepository.findAll()).thenReturn(projects);
+        doThrow(new RuntimeException("점수 계산 실패1"))
+            .when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project1.getId());
+        doThrow(new RuntimeException("점수 계산 실패2"))
+            .when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project2.getId());
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, times(2))
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 성공 - 단일 프로젝트")
+    void calculateAllBoostingScores_SingleProject() {
+        // given
+        Project project = Project.builder()
+            .id(UUID.randomUUID())
+            .name("단일 프로젝트")
+            .build();
+
+        when(projectRepository.findAll()).thenReturn(List.of(project));
+        doNothing().when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(project.getId());
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, times(1))
+            .calculateAndSaveScoresForProjectFromScheduler(project.getId());
+    }
+
+    @Test
+    @DisplayName("스케줄러 실행 성공 - 다수의 프로젝트")
+    void calculateAllBoostingScores_ManyProjects() {
+        // given
+        List<Project> projects = List.of(
+            Project.builder().id(UUID.randomUUID()).name("프로젝트1").build(),
+            Project.builder().id(UUID.randomUUID()).name("프로젝트2").build(),
+            Project.builder().id(UUID.randomUUID()).name("프로젝트3").build(),
+            Project.builder().id(UUID.randomUUID()).name("프로젝트4").build(),
+            Project.builder().id(UUID.randomUUID()).name("프로젝트5").build()
+        );
+
+        when(projectRepository.findAll()).thenReturn(projects);
+        doNothing().when(boostingScoreService)
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+
+        // when
+        boostingScoreScheduler.calculateAllBoostingScores();
+
+        // then
+        verify(projectRepository, times(1)).findAll();
+        verify(boostingScoreService, times(5))
+            .calculateAndSaveScoresForProjectFromScheduler(any(UUID.class));
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/boostingScore/service/BoostingScoreServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/boostingScore/service/BoostingScoreServiceTest.java
@@ -1,0 +1,366 @@
+package knu.team1.be.boost.boostingScore.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.boostingScore.config.BoostingScoreConfig;
+import knu.team1.be.boost.boostingScore.dto.BoostingScoreResponseDto;
+import knu.team1.be.boost.boostingScore.entity.BoostingScore;
+import knu.team1.be.boost.boostingScore.repository.BoostingScoreRepository;
+import knu.team1.be.boost.comment.repository.CommentRepository;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.common.policy.AccessPolicy;
+import knu.team1.be.boost.member.entity.Member;
+import knu.team1.be.boost.project.entity.Project;
+import knu.team1.be.boost.projectMembership.entity.ProjectMembership;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
+import knu.team1.be.boost.projectMembership.repository.ProjectMembershipRepository;
+import knu.team1.be.boost.task.entity.Task;
+import knu.team1.be.boost.task.entity.TaskStatus;
+import knu.team1.be.boost.task.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoostingScoreServiceTest {
+
+    @InjectMocks
+    private BoostingScoreService boostingScoreService;
+
+    @Mock
+    private BoostingScoreRepository boostingScoreRepository;
+
+    @Mock
+    private ProjectMembershipRepository projectMembershipRepository;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private BoostingScoreConfig scoreConfig;
+
+    @Mock
+    private BoostingScoreConfig.TaskScoreConfig taskScoreConfig;
+
+    @Mock
+    private AccessPolicy accessPolicy;
+
+    private final UUID projectId = UUID.randomUUID();
+    private final UUID memberId = UUID.randomUUID();
+
+    private Project testProject;
+    private Member testMember;
+    private ProjectMembership testMembership;
+    private BoostingScore testScore;
+
+    @BeforeEach
+    void setUp() {
+        testProject = Project.builder()
+            .id(projectId)
+            .name("테스트 프로젝트")
+            .build();
+
+        testMember = Member.builder()
+            .id(memberId)
+            .name("테스트유저")
+            .avatar("1111")
+            .build();
+
+        testMembership = ProjectMembership.builder()
+            .id(UUID.randomUUID())
+            .project(testProject)
+            .member(testMember)
+            .role(ProjectRole.MEMBER)
+            .build();
+
+        testScore = BoostingScore.create(
+            testMembership,
+            10,
+            5,
+            6,
+            LocalDateTime.now()
+        );
+    }
+
+    private void setupScoreConfig() {
+        lenient().when(scoreConfig.getTask()).thenReturn(taskScoreConfig);
+        lenient().when(scoreConfig.getCommentScore()).thenReturn(1);
+        lenient().when(scoreConfig.getApproveScore()).thenReturn(3);
+        lenient().when(taskScoreConfig.getTodo()).thenReturn(1);
+        lenient().when(taskScoreConfig.getProgress()).thenReturn(2);
+        lenient().when(taskScoreConfig.getReview()).thenReturn(3);
+        lenient().when(taskScoreConfig.getDone()).thenReturn(5);
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 성공 - 기존 점수 존재")
+    void getProjectBoostingScores_Success_ExistingScores() {
+        // given
+        List<BoostingScore> scores = List.of(testScore);
+
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(boostingScoreRepository.existsByProjectId(projectId)).thenReturn(true);
+        when(boostingScoreRepository.findLatestByProjectId(projectId)).thenReturn(scores);
+
+        // when
+        List<BoostingScoreResponseDto> result = boostingScoreService.getProjectBoostingScores(
+            projectId,
+            memberId
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).memberId()).isEqualTo(memberId);
+        assertThat(result.get(0).totalScore()).isEqualTo(21);
+        assertThat(result.get(0).rank()).isEqualTo(1);
+
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(boostingScoreRepository, times(1)).existsByProjectId(projectId);
+        verify(boostingScoreRepository, times(1)).findLatestByProjectId(projectId);
+        verify(boostingScoreRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 성공 - 점수 없음, 새로 계산")
+    void getProjectBoostingScores_Success_CalculateNew() {
+        // given
+        setupScoreConfig();
+        List<BoostingScore> scores = List.of(testScore);
+        List<Task> tasks = List.of(
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.DONE).build()
+        );
+
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(boostingScoreRepository.existsByProjectId(projectId)).thenReturn(false);
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, memberId))
+            .thenReturn(tasks);
+        when(commentRepository.countByTaskProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(5L);
+        when(taskRepository.countByProjectIdAndApproversId(projectId, memberId))
+            .thenReturn(2L);
+        when(boostingScoreRepository.save(any(BoostingScore.class)))
+            .thenReturn(testScore);
+        when(boostingScoreRepository.findLatestByProjectId(projectId)).thenReturn(scores);
+
+        // when
+        List<BoostingScoreResponseDto> result = boostingScoreService.getProjectBoostingScores(
+            projectId,
+            memberId
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(1);
+
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(boostingScoreRepository, times(1)).existsByProjectId(projectId);
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(boostingScoreRepository, times(1)).save(any(BoostingScore.class));
+        verify(boostingScoreRepository, times(1)).findLatestByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 공헌도 점수 조회 실패 - 권한 없음")
+    void getProjectBoostingScores_Fail_NoPermission() {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY))
+            .when(accessPolicy).ensureProjectMember(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> boostingScoreService.getProjectBoostingScores(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_MEMBER_ONLY);
+
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(boostingScoreRepository, never()).existsByProjectId(any());
+    }
+
+    @Test
+    @DisplayName("API 호출로 점수 계산 및 저장 성공")
+    void calculateAndSaveScoresForProjectFromApi_Success() {
+        // given
+        setupScoreConfig();
+        List<Task> tasks = List.of(
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.DONE).build(),
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.REVIEW).build()
+        );
+
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, memberId))
+            .thenReturn(tasks);
+        when(commentRepository.countByTaskProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(3L);
+        when(taskRepository.countByProjectIdAndApproversId(projectId, memberId))
+            .thenReturn(2L);
+        when(boostingScoreRepository.save(any(BoostingScore.class)))
+            .thenReturn(testScore);
+
+        // when
+        boostingScoreService.calculateAndSaveScoresForProjectFromApi(projectId);
+
+        // then
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(taskRepository, times(1)).findAllByProjectIdAndAssigneesId(projectId, memberId);
+        verify(commentRepository, times(1)).countByTaskProjectIdAndMemberId(projectId, memberId);
+        verify(taskRepository, times(1)).countByProjectIdAndApproversId(projectId, memberId);
+        verify(boostingScoreRepository, times(1)).save(any(BoostingScore.class));
+    }
+
+    @Test
+    @DisplayName("API 호출로 점수 계산 - 멤버십 없음")
+    void calculateAndSaveScoresForProjectFromApi_NoMemberships() {
+        // given
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of());
+
+        // when
+        boostingScoreService.calculateAndSaveScoresForProjectFromApi(projectId);
+
+        // then
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(boostingScoreRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("API 호출로 점수 계산 실패 - 모든 멤버 계산 실패")
+    void calculateAndSaveScoresForProjectFromApi_Fail_AllMembersFailed() {
+        // given
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(any(), any()))
+            .thenThrow(new RuntimeException("DB 오류"));
+
+        // when & then
+        assertThatThrownBy(
+            () -> boostingScoreService.calculateAndSaveScoresForProjectFromApi(projectId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode",
+                ErrorCode.BOOSTING_SCORE_CALCULATION_FAILED);
+
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(boostingScoreRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("스케줄러 호출로 점수 계산 및 저장 성공")
+    void calculateAndSaveScoresForProjectFromScheduler_Success() {
+        // given
+        setupScoreConfig();
+        List<Task> tasks = List.of(
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.TODO).build()
+        );
+
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, memberId))
+            .thenReturn(tasks);
+        when(commentRepository.countByTaskProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(10L);
+        when(taskRepository.countByProjectIdAndApproversId(projectId, memberId))
+            .thenReturn(5L);
+        when(boostingScoreRepository.save(any(BoostingScore.class)))
+            .thenReturn(testScore);
+
+        // when
+        boostingScoreService.calculateAndSaveScoresForProjectFromScheduler(projectId);
+
+        // then
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(boostingScoreRepository, times(1)).save(any(BoostingScore.class));
+    }
+
+    @Test
+    @DisplayName("스케줄러 호출로 점수 계산 - 일부 멤버 실패해도 계속 진행")
+    void calculateAndSaveScoresForProjectFromScheduler_PartialFailure() {
+        // given
+        setupScoreConfig();
+        Member member2 = Member.builder()
+            .id(UUID.randomUUID())
+            .name("멤버2")
+            .avatar("2222")
+            .build();
+
+        ProjectMembership membership2 = ProjectMembership.builder()
+            .id(UUID.randomUUID())
+            .project(testProject)
+            .member(member2)
+            .role(ProjectRole.MEMBER)
+            .build();
+
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership, membership2));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, memberId))
+            .thenThrow(new RuntimeException("첫 번째 멤버 오류"));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, member2.getId()))
+            .thenReturn(List.of());
+        when(commentRepository.countByTaskProjectIdAndMemberId(projectId, member2.getId()))
+            .thenReturn(1L);
+        when(taskRepository.countByProjectIdAndApproversId(projectId, member2.getId()))
+            .thenReturn(0L);
+        when(boostingScoreRepository.save(any(BoostingScore.class)))
+            .thenReturn(testScore);
+
+        // when
+        boostingScoreService.calculateAndSaveScoresForProjectFromScheduler(projectId);
+
+        // then
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+        verify(boostingScoreRepository, times(1)).save(any(BoostingScore.class));
+    }
+
+    @Test
+    @DisplayName("Task 점수 계산 - 다양한 상태")
+    void calculateTaskScore_VariousStatuses() {
+        // given
+        setupScoreConfig();
+        List<Task> tasks = List.of(
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.TODO).build(),
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.PROGRESS).build(),
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.REVIEW).build(),
+            Task.builder().id(UUID.randomUUID()).status(TaskStatus.DONE).build()
+        );
+
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership));
+        when(taskRepository.findAllByProjectIdAndAssigneesId(projectId, memberId))
+            .thenReturn(tasks);
+        when(commentRepository.countByTaskProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(0L);
+        when(taskRepository.countByProjectIdAndApproversId(projectId, memberId))
+            .thenReturn(0L);
+        when(boostingScoreRepository.save(any(BoostingScore.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        boostingScoreService.calculateAndSaveScoresForProjectFromApi(projectId);
+
+        // then
+        verify(boostingScoreRepository, times(1)).save(any(BoostingScore.class));
+    }
+}
+


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
Boosting Score 패키지의 단위 테스트 코드 작성 (Service, Controller, Scheduler)

### ✨ 작업 내용

#### 테스트 파일 추가 (3개)

1. BoostingScoreServiceTest (9개 테스트)
   - 공헌도 점수 조회 (기존/신규 계산)
   - API/스케줄러 호출 시 점수 계산 로직
   - 권한 검증 및 예외 처리

2. BoostingScoreControllerTest (6개 테스트)  
   - GET `/api/projects/{projectId}/boosting-scores` 엔드포인트
   - 성공/실패 케이스 (403, 404, 500)
   - MockMvc 활용한 HTTP 요청 검증

3. BoostingScoreSchedulerTest (7개 테스트)
   - 매시간 실행되는 스케줄러 로직
   - 다수 프로젝트 처리 및 부분 실패 시나리오
   - 예외 발생 시 로직 검증

### #️⃣ 연관 이슈
- Close #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 부스팅 점수 기능에 대한 포괄적인 테스트 커버리지 추가 (컨트롤러, 스케줄러, 서비스 계층)

---

**사용자 영향 없음**: 이 변경사항은 내부 테스트 인프라 개선 사항입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->