### PR TITLE
✅ 프로젝트 단위 테스트 코드 추가

### DIFF
--- a/src/test/java/knu/team1/be/boost/project/controller/ProjectControllerTest.java
+++ b/src/test/java/knu/team1/be/boost/project/controller/ProjectControllerTest.java
@@ -1,0 +1,457 @@
+package knu.team1.be.boost.project.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.member.dto.MemberResponseDto;
+import knu.team1.be.boost.project.dto.ProjectCreateRequestDto;
+import knu.team1.be.boost.project.dto.ProjectResponseDto;
+import knu.team1.be.boost.project.dto.ProjectUpdateRequestDto;
+import knu.team1.be.boost.project.service.ProjectService;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
+import knu.team1.be.boost.security.filter.JwtAuthFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@WebMvcTest(
+    controllers = ProjectController.class,
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        OAuth2ClientAutoConfiguration.class
+    },
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JwtAuthFilter.class
+    )
+)
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    private static final UUID testUserId = TestSecurityConfig.testUserPrincipal.id();
+    private final UUID projectId = UUID.randomUUID();
+
+    @TestConfiguration
+    static class TestSecurityConfig implements WebMvcConfigurer {
+
+        static UserPrincipalDto testUserPrincipal = new UserPrincipalDto(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "테스트유저",
+            "1111"
+        );
+
+        @Bean
+        public HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver() {
+            return new HandlerMethodArgumentResolver() {
+                @Override
+                public boolean supportsParameter(MethodParameter parameter) {
+                    return parameter.getParameterType().equals(UserPrincipalDto.class) &&
+                        parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+                }
+
+                @Override
+                public Object resolveArgument(
+                    MethodParameter parameter,
+                    ModelAndViewContainer mavContainer,
+                    NativeWebRequest webRequest,
+                    WebDataBinderFactory binderFactory
+                ) {
+                    return testUserPrincipal;
+                }
+            };
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(authenticationPrincipalArgumentResolver());
+        }
+    }
+
+    private ProjectResponseDto createMockProjectResponseDto(UUID id, String name) {
+        return new ProjectResponseDto(
+            id,
+            name,
+            2,
+            ProjectRole.OWNER,
+            true
+        );
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 성공")
+    void createProject_Success() throws Exception {
+        // given
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto("새 프로젝트");
+        ProjectResponseDto responseDto = createMockProjectResponseDto(projectId, "새 프로젝트");
+
+        when(projectService.createProject(any(ProjectCreateRequestDto.class), eq(testUserId)))
+            .thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(projectId.toString()))
+            .andExpect(jsonPath("$.name").value("새 프로젝트"))
+            .andExpect(jsonPath("$.role").value("OWNER"))
+            .andDo(print());
+
+        verify(projectService, times(1))
+            .createProject(any(ProjectCreateRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 실패 - Validation Error (이름 없음)")
+    void createProject_Fail_EmptyName() throws Exception {
+        // given
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto("");
+
+        // when & then
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+
+        verify(projectService, never()).createProject(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 실패 - Validation Error (이름 너무 김)")
+    void createProject_Fail_NameTooLong() throws Exception {
+        // given
+        String longName = "a".repeat(31);
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto(longName);
+
+        // when & then
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+
+        verify(projectService, never()).createProject(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 성공")
+    void getProject_Success() throws Exception {
+        // given
+        ProjectResponseDto responseDto = createMockProjectResponseDto(projectId, "테스트 프로젝트");
+
+        when(projectService.getProject(projectId, testUserId)).thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(projectId.toString()))
+            .andExpect(jsonPath("$.name").value("테스트 프로젝트"))
+            .andDo(print());
+
+        verify(projectService, times(1)).getProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 실패 - 프로젝트 없음")
+    void getProject_Fail_ProjectNotFound() throws Exception {
+        // given
+        when(projectService.getProject(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(projectService, times(1)).getProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 실패 - 권한 없음")
+    void getProject_Fail_NoPermission() throws Exception {
+        // given
+        when(projectService.getProject(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectService, times(1)).getProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("내 프로젝트 목록 조회 성공")
+    void getMyProjects_Success() throws Exception {
+        // given
+        List<ProjectResponseDto> projects = List.of(
+            createMockProjectResponseDto(UUID.randomUUID(), "프로젝트1"),
+            createMockProjectResponseDto(UUID.randomUUID(), "프로젝트2")
+        );
+
+        when(projectService.getMyProjects(testUserId)).thenReturn(projects);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/me")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(2))
+            .andExpect(jsonPath("$[0].name").value("프로젝트1"))
+            .andExpect(jsonPath("$[1].name").value("프로젝트2"))
+            .andDo(print());
+
+        verify(projectService, times(1)).getMyProjects(testUserId);
+    }
+
+    @Test
+    @DisplayName("내 프로젝트 목록 조회 - 빈 리스트")
+    void getMyProjects_EmptyList() throws Exception {
+        // given
+        when(projectService.getMyProjects(testUserId)).thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/projects/me")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(0))
+            .andDo(print());
+
+        verify(projectService, times(1)).getMyProjects(testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 성공")
+    void updateProject_Success() throws Exception {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("수정된 프로젝트", 3);
+        ProjectResponseDto responseDto = new ProjectResponseDto(
+            projectId,
+            "수정된 프로젝트",
+            3,
+            ProjectRole.OWNER,
+            true
+        );
+
+        when(projectService.updateProject(eq(projectId), any(ProjectUpdateRequestDto.class),
+            eq(testUserId)))
+            .thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(put("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(projectId.toString()))
+            .andExpect(jsonPath("$.name").value("수정된 프로젝트"))
+            .andExpect(jsonPath("$.defaultReviewerCount").value(3))
+            .andDo(print());
+
+        verify(projectService, times(1))
+            .updateProject(eq(projectId), any(ProjectUpdateRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 실패 - Validation Error")
+    void updateProject_Fail_ValidationError() throws Exception {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("", -1);
+
+        // when & then
+        mockMvc.perform(put("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+
+        verify(projectService, never()).updateProject(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 실패 - 권한 없음")
+    void updateProject_Fail_NotOwner() throws Exception {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("수정된 프로젝트", 3);
+
+        when(projectService.updateProject(any(), any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY));
+
+        // when & then
+        mockMvc.perform(put("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectService, times(1))
+            .updateProject(eq(projectId), any(ProjectUpdateRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 성공")
+    void deleteProject_Success() throws Exception {
+        // given
+        doNothing().when(projectService).deleteProject(projectId, testUserId);
+
+        // when & then
+        mockMvc.perform(delete("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent())
+            .andDo(print());
+
+        verify(projectService, times(1)).deleteProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 프로젝트 없음")
+    void deleteProject_Fail_ProjectNotFound() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND))
+            .when(projectService).deleteProject(any(), any());
+
+        // when & then
+        mockMvc.perform(delete("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(projectService, times(1)).deleteProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 권한 없음")
+    void deleteProject_Fail_NotOwner() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY))
+            .when(projectService).deleteProject(any(), any());
+
+        // when & then
+        mockMvc.perform(delete("/api/projects/{projectId}", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectService, times(1)).deleteProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 성공")
+    void getProjectMembers_Success() throws Exception {
+        // given
+        MemberResponseDto member1 = new MemberResponseDto(
+            UUID.randomUUID(),
+            "멤버1",
+            "1111",
+            "#FF5733",
+            true,
+            null,
+            null
+        );
+
+        MemberResponseDto member2 = new MemberResponseDto(
+            UUID.randomUUID(),
+            "멤버2",
+            "2222",
+            "#0000FF",
+            true,
+            null,
+            null
+        );
+
+        List<MemberResponseDto> members = List.of(member1, member2);
+
+        when(projectService.getProjectMembers(projectId, testUserId)).thenReturn(members);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/members", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()").value(2))
+            .andExpect(jsonPath("$[0].name").value("멤버1"))
+            .andExpect(jsonPath("$[1].name").value("멤버2"))
+            .andDo(print());
+
+        verify(projectService, times(1)).getProjectMembers(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 실패 - 프로젝트 없음")
+    void getProjectMembers_Fail_ProjectNotFound() throws Exception {
+        // given
+        when(projectService.getProjectMembers(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/members", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(projectService, times(1)).getProjectMembers(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 실패 - 권한 없음")
+    void getProjectMembers_Fail_NoPermission() throws Exception {
+        // given
+        when(projectService.getProjectMembers(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/members", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectService, times(1)).getProjectMembers(projectId, testUserId);
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/project/service/ProjectServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/project/service/ProjectServiceTest.java
@@ -1,0 +1,427 @@
+package knu.team1.be.boost.project.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.common.policy.AccessPolicy;
+import knu.team1.be.boost.member.dto.MemberResponseDto;
+import knu.team1.be.boost.member.entity.Member;
+import knu.team1.be.boost.member.repository.MemberRepository;
+import knu.team1.be.boost.project.dto.ProjectCreateRequestDto;
+import knu.team1.be.boost.project.dto.ProjectResponseDto;
+import knu.team1.be.boost.project.dto.ProjectUpdateRequestDto;
+import knu.team1.be.boost.project.entity.Project;
+import knu.team1.be.boost.project.repository.ProjectRepository;
+import knu.team1.be.boost.projectMembership.entity.ProjectMembership;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
+import knu.team1.be.boost.projectMembership.repository.ProjectMembershipRepository;
+import knu.team1.be.boost.tag.repository.TagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProjectMembershipRepository projectMembershipRepository;
+
+    @Mock
+    private AccessPolicy accessPolicy;
+
+    private final UUID projectId = UUID.randomUUID();
+    private final UUID memberId = UUID.randomUUID();
+
+    private Project testProject;
+    private Member testMember;
+    private ProjectMembership testMembership;
+
+    @BeforeEach
+    void setUp() {
+        testProject = Project.builder()
+            .id(projectId)
+            .name("테스트 프로젝트")
+            .defaultReviewerCount(2)
+            .build();
+
+        testMember = Member.builder()
+            .id(memberId)
+            .name("테스트유저")
+            .avatar("1111")
+            .backgroundColor("#FF5733")
+            .build();
+
+        testMembership = ProjectMembership.builder()
+            .id(UUID.randomUUID())
+            .project(testProject)
+            .member(testMember)
+            .role(ProjectRole.OWNER)
+            .notificationEnabled(true)
+            .build();
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 성공")
+    void createProject_Success() {
+        // given
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto("새 프로젝트");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(projectRepository.save(any(Project.class))).thenReturn(testProject);
+        when(projectMembershipRepository.save(any(ProjectMembership.class)))
+            .thenReturn(testMembership);
+
+        // when
+        ProjectResponseDto result = projectService.createProject(requestDto, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(projectId);
+        assertThat(result.name()).isEqualTo("테스트 프로젝트");
+        assertThat(result.defaultReviewerCount()).isEqualTo(2);
+        assertThat(result.role()).isEqualTo(ProjectRole.OWNER);
+        assertThat(result.isNotificationEnabled()).isTrue();
+
+        verify(memberRepository, times(1)).findById(memberId);
+        verify(projectRepository, times(1)).save(any(Project.class));
+        verify(projectMembershipRepository, times(1)).save(any(ProjectMembership.class));
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성 실패 - 멤버 없음")
+    void createProject_Fail_MemberNotFound() {
+        // given
+        ProjectCreateRequestDto requestDto = new ProjectCreateRequestDto("새 프로젝트");
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.createProject(requestDto, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+        verify(memberRepository, times(1)).findById(memberId);
+        verify(projectRepository, never()).save(any());
+        verify(projectMembershipRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 성공")
+    void getProject_Success() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(projectMembershipRepository.findByProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(Optional.of(testMembership));
+
+        // when
+        ProjectResponseDto result = projectService.getProject(projectId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(projectId);
+        assertThat(result.name()).isEqualTo("테스트 프로젝트");
+        assertThat(result.role()).isEqualTo(ProjectRole.OWNER);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectMembershipRepository, times(1))
+            .findByProjectIdAndMemberId(projectId, memberId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 실패 - 프로젝트 없음")
+    void getProject_Fail_ProjectNotFound() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.getProject(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NOT_FOUND);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, never()).ensureProjectMember(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 조회 실패 - 권한 없음")
+    void getProject_Fail_NoPermission() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY))
+            .when(accessPolicy).ensureProjectMember(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectService.getProject(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_MEMBER_ONLY);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectMembershipRepository, never()).findByProjectIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("내 프로젝트 목록 조회 성공")
+    void getMyProjects_Success() {
+        // given
+        ProjectMembership membership2 = ProjectMembership.builder()
+            .id(UUID.randomUUID())
+            .project(Project.builder().id(UUID.randomUUID()).name("프로젝트2").defaultReviewerCount(3).build())
+            .member(testMember)
+            .role(ProjectRole.MEMBER)
+            .notificationEnabled(false)
+            .build();
+
+        when(projectMembershipRepository.findAllByMemberId(memberId))
+            .thenReturn(List.of(testMembership, membership2));
+
+        // when
+        List<ProjectResponseDto> result = projectService.getMyProjects(memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).name()).isEqualTo("테스트 프로젝트");
+        assertThat(result.get(0).role()).isEqualTo(ProjectRole.OWNER);
+        assertThat(result.get(1).name()).isEqualTo("프로젝트2");
+        assertThat(result.get(1).role()).isEqualTo(ProjectRole.MEMBER);
+
+        verify(projectMembershipRepository, times(1)).findAllByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("내 프로젝트 목록 조회 - 빈 리스트")
+    void getMyProjects_EmptyList() {
+        // given
+        when(projectMembershipRepository.findAllByMemberId(memberId))
+            .thenReturn(List.of());
+
+        // when
+        List<ProjectResponseDto> result = projectService.getMyProjects(memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+
+        verify(projectMembershipRepository, times(1)).findAllByMemberId(memberId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 성공")
+    void updateProject_Success() {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("수정된 프로젝트", 3);
+
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doNothing().when(accessPolicy).ensureProjectOwner(projectId, memberId);
+        when(projectMembershipRepository.findByProjectIdAndMemberId(projectId, memberId))
+            .thenReturn(Optional.of(testMembership));
+
+        // when
+        ProjectResponseDto result = projectService.updateProject(projectId, requestDto, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(projectId);
+        assertThat(result.role()).isEqualTo(ProjectRole.OWNER);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(projectMembershipRepository, times(1))
+            .findByProjectIdAndMemberId(projectId, memberId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 실패 - 프로젝트 없음")
+    void updateProject_Fail_ProjectNotFound() {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("수정된 프로젝트", 3);
+
+        when(projectRepository.findById(projectId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.updateProject(projectId, requestDto, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NOT_FOUND);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, never()).ensureProjectOwner(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 수정 실패 - 권한 없음 (Owner 아님)")
+    void updateProject_Fail_NotOwner() {
+        // given
+        ProjectUpdateRequestDto requestDto = new ProjectUpdateRequestDto("수정된 프로젝트", 3);
+
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY))
+            .when(accessPolicy).ensureProjectOwner(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectService.updateProject(projectId, requestDto, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_OWNER_ONLY);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(projectMembershipRepository, never()).findByProjectIdAndMemberId(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 성공")
+    void deleteProject_Success() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doNothing().when(accessPolicy).ensureProjectOwner(projectId, memberId);
+        doNothing().when(tagRepository).deleteAllByProjectId(projectId);
+        doNothing().when(projectMembershipRepository).softDeleteAllByProjectId(projectId);
+        doNothing().when(projectRepository).delete(testProject);
+
+        // when
+        projectService.deleteProject(projectId, memberId);
+
+        // then
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(tagRepository, times(1)).deleteAllByProjectId(projectId);
+        verify(projectMembershipRepository, times(1)).softDeleteAllByProjectId(projectId);
+        verify(projectRepository, times(1)).delete(testProject);
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 프로젝트 없음")
+    void deleteProject_Fail_ProjectNotFound() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> projectService.deleteProject(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NOT_FOUND);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, never()).ensureProjectOwner(any(), any());
+        verify(projectRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제 실패 - 권한 없음")
+    void deleteProject_Fail_NotOwner() {
+        // given
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(testProject));
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY))
+            .when(accessPolicy).ensureProjectOwner(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectService.deleteProject(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_OWNER_ONLY);
+
+        verify(projectRepository, times(1)).findById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(projectRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 성공")
+    void getProjectMembers_Success() {
+        // given
+        Member member2 = Member.builder()
+            .id(UUID.randomUUID())
+            .name("멤버2")
+            .avatar("2222")
+            .backgroundColor("#0000FF")
+            .build();
+
+        ProjectMembership membership2 = ProjectMembership.builder()
+            .id(UUID.randomUUID())
+            .project(testProject)
+            .member(member2)
+            .role(ProjectRole.MEMBER)
+            .notificationEnabled(true)
+            .build();
+
+        when(projectRepository.existsById(projectId)).thenReturn(true);
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(projectMembershipRepository.findAllByProjectId(projectId))
+            .thenReturn(List.of(testMembership, membership2));
+
+        // when
+        List<MemberResponseDto> result = projectService.getProjectMembers(projectId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).name()).isEqualTo("테스트유저");
+        assertThat(result.get(1).name()).isEqualTo("멤버2");
+
+        verify(projectRepository, times(1)).existsById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectMembershipRepository, times(1)).findAllByProjectId(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 실패 - 프로젝트 없음")
+    void getProjectMembers_Fail_ProjectNotFound() {
+        // given
+        when(projectRepository.existsById(projectId)).thenReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> projectService.getProjectMembers(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NOT_FOUND);
+
+        verify(projectRepository, times(1)).existsById(projectId);
+        verify(accessPolicy, never()).ensureProjectMember(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 멤버 목록 조회 실패 - 권한 없음")
+    void getProjectMembers_Fail_NoPermission() {
+        // given
+        when(projectRepository.existsById(projectId)).thenReturn(true);
+        doThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY))
+            .when(accessPolicy).ensureProjectMember(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectService.getProjectMembers(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_MEMBER_ONLY);
+
+        verify(projectRepository, times(1)).existsById(projectId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectMembershipRepository, never()).findAllByProjectId(any());
+    }
+}
+


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약
- Project 패키지의 단위 테스트 코드 작성 (Service, Controller)

### ✨ 작업 내용

#### 테스트 파일 추가 (2개)

1. ProjectServiceTest (16개 테스트)

   - 프로젝트 생성 (성공/멤버 없음)
   - 프로젝트 조회 (성공/프로젝트 없음/권한 없음)
   - 내 프로젝트 목록 조회 (성공/빈 리스트)
   - 프로젝트 수정 (성공/프로젝트 없음/Owner 아님)
   - 프로젝트 삭제 (성공/프로젝트 없음/권한 없음)
   - 프로젝트 멤버 목록 조회 (성공/프로젝트 없음/권한 없음)

2. ProjectControllerTest (17개 테스트)

   - POST `/api/projects` 엔드포인트 (성공/Validation 에러)
   - GET `/api/projects/{projectId}` (성공/404/403)
   - GET `/api/projects/me` (성공/빈 리스트)
   - PUT `/api/projects/{projectId}` (성공/Validation 에러/403)
   - DELETE `/api/projects/{projectId}` (성공/404/403)
   - GET `/api/projects/{projectId}/members` (성공/404/403)
   - MockMvc 활용한 HTTP 요청/응답 검증

### #️⃣ 연관 이슈
- Close #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트

- 프로젝트 컨트롤러 및 서비스 계층에 대한 포괄적인 단위 테스트 스위트 추가
- 프로젝트 생성, 조회, 업데이트, 삭제 및 멤버 관리 기능에 대한 테스트 커버리지 확대
- 성공 시나리오 및 검증 오류, 권한 오류, 데이터 누락 등 다양한 실패 사례 테스트
- 서비스 계층과 컨트롤러 엔드포인트의 동작 검증을 통한 애플리케이션 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->