### PR TITLE
✅ 프로젝트 멤버십 관련 컨트롤러 및 서비스 테스트 코드 추가

### DIFF
--- a/src/test/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipControllerTest.java
+++ b/src/test/java/knu/team1/be/boost/projectMembership/controller/ProjectMembershipControllerTest.java
@@ -1,0 +1,392 @@
+package knu.team1.be.boost.projectMembership.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import knu.team1.be.boost.auth.dto.UserPrincipalDto;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinCodeResponseDto;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinRequestDto;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinResponseDto;
+import knu.team1.be.boost.projectMembership.service.ProjectMembershipService;
+import knu.team1.be.boost.security.filter.JwtAuthFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@WebMvcTest(
+    controllers = ProjectMembershipController.class,
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        OAuth2ClientAutoConfiguration.class
+    },
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = JwtAuthFilter.class
+    )
+)
+class ProjectMembershipControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ProjectMembershipService projectMembershipService;
+
+    private static final UUID testUserId = TestSecurityConfig.testUserPrincipal.id();
+    private final UUID projectId = UUID.randomUUID();
+    private final UUID targetMemberId = UUID.randomUUID();
+
+    @TestConfiguration
+    static class TestSecurityConfig implements WebMvcConfigurer {
+
+        static UserPrincipalDto testUserPrincipal = new UserPrincipalDto(
+            UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            "테스트유저",
+            "1111"
+        );
+
+        @Bean
+        public HandlerMethodArgumentResolver authenticationPrincipalArgumentResolver() {
+            return new HandlerMethodArgumentResolver() {
+                @Override
+                public boolean supportsParameter(MethodParameter parameter) {
+                    return parameter.getParameterType().equals(UserPrincipalDto.class) &&
+                        parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+                }
+
+                @Override
+                public Object resolveArgument(
+                    MethodParameter parameter,
+                    ModelAndViewContainer mavContainer,
+                    NativeWebRequest webRequest,
+                    WebDataBinderFactory binderFactory
+                ) {
+                    return testUserPrincipal;
+                }
+            };
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(authenticationPrincipalArgumentResolver());
+        }
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 성공")
+    void createProjectJoinCode_Success() throws Exception {
+        // given
+        ProjectJoinCodeResponseDto responseDto = new ProjectJoinCodeResponseDto(
+            "A1B2C3",
+            LocalDateTime.now().plusDays(7)
+        );
+
+        when(projectMembershipService.generateCode(projectId, testUserId))
+            .thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/projects/{projectId}/join-code", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.joinCode").value("A1B2C3"))
+            .andExpect(jsonPath("$.expiresAt").exists())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).generateCode(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 실패 - 프로젝트 없음")
+    void createProjectJoinCode_Fail_ProjectNotFound() throws Exception {
+        // given
+        when(projectMembershipService.generateCode(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/projects/{projectId}/join-code", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).generateCode(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 실패 - 권한 없음")
+    void createProjectJoinCode_Fail_NoPermission() throws Exception {
+        // given
+        when(projectMembershipService.generateCode(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY));
+
+        // when & then
+        mockMvc.perform(post("/api/projects/{projectId}/join-code", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).generateCode(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 조회 성공")
+    void getProjectJoinCode_Success() throws Exception {
+        // given
+        ProjectJoinCodeResponseDto responseDto = new ProjectJoinCodeResponseDto(
+            "A1B2C3",
+            LocalDateTime.now().plusDays(7)
+        );
+
+        when(projectMembershipService.getCode(projectId, testUserId)).thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/join-code", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.joinCode").value("A1B2C3"))
+            .andExpect(jsonPath("$.expiresAt").exists())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).getCode(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 조회 실패 - 권한 없음")
+    void getProjectJoinCode_Fail_NoPermission() throws Exception {
+        // given
+        when(projectMembershipService.getCode(any(), any()))
+            .thenThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY));
+
+        // when & then
+        mockMvc.perform(get("/api/projects/{projectId}/join-code", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).getCode(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 성공")
+    void joinProject_Success() throws Exception {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("A1B2C3");
+        ProjectJoinResponseDto responseDto = new ProjectJoinResponseDto(projectId);
+
+        when(projectMembershipService.joinProject(any(ProjectJoinRequestDto.class),
+            eq(testUserId)))
+            .thenReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(post("/api/projects/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.projectId").value(projectId.toString()))
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .joinProject(any(ProjectJoinRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 실패 - Validation Error (코드 형식 오류)")
+    void joinProject_Fail_ValidationError() throws Exception {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("");
+
+        // when & then
+        mockMvc.perform(post("/api/projects/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+
+        verify(projectMembershipService, never()).joinProject(any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 실패 - 유효하지 않은 코드")
+    void joinProject_Fail_InvalidCode() throws Exception {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("XXXXXX");
+
+        when(projectMembershipService.joinProject(any(ProjectJoinRequestDto.class), any()))
+            .thenThrow(new BusinessException(ErrorCode.JOIN_CODE_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(post("/api/projects/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isNotFound())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .joinProject(any(ProjectJoinRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 실패 - 이미 참여 중")
+    void joinProject_Fail_AlreadyMember() throws Exception {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("A1B2C3");
+
+        when(projectMembershipService.joinProject(any(ProjectJoinRequestDto.class), any()))
+            .thenThrow(new BusinessException(ErrorCode.MEMBER_ALREADY_JOINED));
+
+        // when & then
+        mockMvc.perform(post("/api/projects/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isConflict())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .joinProject(any(ProjectJoinRequestDto.class), eq(testUserId));
+    }
+
+    @Test
+    @DisplayName("프로젝트 나가기 성공")
+    void leaveProject_Success() throws Exception {
+        // given
+        doNothing().when(projectMembershipService).leaveProject(projectId, testUserId);
+
+        // when & then
+        mockMvc.perform(delete("/api/projects/{projectId}/leave", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).leaveProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 나가기 실패 - Owner는 나갈 수 없음")
+    void leaveProject_Fail_OwnerCannotLeave() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_CANNOT_LEAVE))
+            .when(projectMembershipService).leaveProject(any(), any());
+
+        // when & then
+        mockMvc.perform(delete("/api/projects/{projectId}/leave", projectId)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1)).leaveProject(projectId, testUserId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 성공")
+    void kickMember_Success() throws Exception {
+        // given
+        doNothing().when(projectMembershipService)
+            .kickMember(projectId, targetMemberId, testUserId);
+
+        // when & then
+        mockMvc.perform(
+                delete("/api/projects/{projectId}/members/{targetMemberId}", projectId,
+                    targetMemberId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .kickMember(projectId, targetMemberId, testUserId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - 권한 없음 (Owner 아님)")
+    void kickMember_Fail_NotOwner() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY))
+            .when(projectMembershipService).kickMember(any(), any(), any());
+
+        // when & then
+        mockMvc.perform(
+                delete("/api/projects/{projectId}/members/{targetMemberId}", projectId,
+                    targetMemberId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .kickMember(projectId, targetMemberId, testUserId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - 자기 자신 추방 시도")
+    void kickMember_Fail_CannotKickSelf() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.CANNOT_KICK_YOURSELF))
+            .when(projectMembershipService).kickMember(any(), any(), any());
+
+        // when & then
+        mockMvc.perform(
+                delete("/api/projects/{projectId}/members/{targetMemberId}", projectId,
+                    targetMemberId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .kickMember(projectId, targetMemberId, testUserId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - Owner 추방 시도")
+    void kickMember_Fail_CannotKickOwner() throws Exception {
+        // given
+        doThrow(new BusinessException(ErrorCode.CANNOT_KICK_OWNER))
+            .when(projectMembershipService).kickMember(any(), any(), any());
+
+        // when & then
+        mockMvc.perform(
+                delete("/api/projects/{projectId}/members/{targetMemberId}", projectId,
+                    targetMemberId)
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andDo(print());
+
+        verify(projectMembershipService, times(1))
+            .kickMember(projectId, targetMemberId, testUserId);
+    }
+}
+

--- a/src/test/java/knu/team1/be/boost/projectMembership/service/ProjectMembershipServiceTest.java
+++ b/src/test/java/knu/team1/be/boost/projectMembership/service/ProjectMembershipServiceTest.java
@@ -1,0 +1,352 @@
+package knu.team1.be.boost.projectMembership.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import knu.team1.be.boost.common.exception.BusinessException;
+import knu.team1.be.boost.common.exception.ErrorCode;
+import knu.team1.be.boost.common.policy.AccessPolicy;
+import knu.team1.be.boost.project.entity.Project;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinCodeResponseDto;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinRequestDto;
+import knu.team1.be.boost.projectMembership.dto.ProjectJoinResponseDto;
+import knu.team1.be.boost.projectMembership.entity.CodeStatus;
+import knu.team1.be.boost.projectMembership.entity.ProjectJoinCode;
+import knu.team1.be.boost.projectMembership.entity.ProjectRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectMembershipServiceTest {
+
+    @InjectMocks
+    private ProjectMembershipService projectMembershipService;
+
+    @Mock
+    private ProjectParticipantService projectParticipantService;
+
+    @Mock
+    private ProjectJoinCodeService projectJoinCodeService;
+
+    @Mock
+    private AccessPolicy accessPolicy;
+
+    private final UUID projectId = UUID.randomUUID();
+    private final UUID memberId = UUID.randomUUID();
+    private final UUID targetMemberId = UUID.randomUUID();
+
+    private Project testProject;
+    private ProjectJoinCode testJoinCode;
+
+    @BeforeEach
+    void setUp() {
+        testProject = Project.builder()
+            .id(projectId)
+            .name("테스트 프로젝트")
+            .defaultReviewerCount(2)
+            .build();
+
+        testJoinCode = ProjectJoinCode.builder()
+            .id(UUID.randomUUID())
+            .project(testProject)
+            .joinCode("A1B2C3")
+            .status(CodeStatus.ACTIVE)
+            .expiresAt(LocalDateTime.now().plusDays(7))
+            .build();
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 성공")
+    void generateCode_Success() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(projectJoinCodeService.generateJoinCode(projectId)).thenReturn(testJoinCode);
+
+        // when
+        ProjectJoinCodeResponseDto result = projectMembershipService.generateCode(projectId,
+            memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.joinCode()).isEqualTo("A1B2C3");
+        assertThat(result.expiresAt()).isNotNull();
+
+        verify(projectParticipantService, times(1)).checkProjectExists(projectId);
+        verify(projectParticipantService, times(1)).checkMemberExists(memberId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectJoinCodeService, times(1)).generateJoinCode(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 실패 - 프로젝트 없음")
+    void generateCode_Fail_ProjectNotFound() {
+        // given
+        doThrow(new BusinessException(ErrorCode.PROJECT_NOT_FOUND))
+            .when(projectParticipantService).checkProjectExists(projectId);
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.generateCode(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_NOT_FOUND);
+
+        verify(projectParticipantService, times(1)).checkProjectExists(projectId);
+        verify(projectJoinCodeService, never()).generateJoinCode(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 생성 실패 - 권한 없음")
+    void generateCode_Fail_NoPermission() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY))
+            .when(accessPolicy).ensureProjectMember(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.generateCode(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_MEMBER_ONLY);
+
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectJoinCodeService, never()).generateJoinCode(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 조회 성공")
+    void getCode_Success() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        when(projectJoinCodeService.getJoinCode(projectId)).thenReturn(testJoinCode);
+
+        // when
+        ProjectJoinCodeResponseDto result = projectMembershipService.getCode(projectId, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.joinCode()).isEqualTo("A1B2C3");
+        assertThat(result.expiresAt()).isNotNull();
+
+        verify(projectParticipantService, times(1)).checkProjectExists(projectId);
+        verify(projectParticipantService, times(1)).checkMemberExists(memberId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectJoinCodeService, times(1)).getJoinCode(projectId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 코드 조회 실패 - 권한 없음")
+    void getCode_Fail_NoPermission() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doThrow(new BusinessException(ErrorCode.PROJECT_MEMBER_ONLY))
+            .when(accessPolicy).ensureProjectMember(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.getCode(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_MEMBER_ONLY);
+
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectJoinCodeService, never()).getJoinCode(any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 성공")
+    void joinProject_Success() {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("A1B2C3");
+
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        when(projectJoinCodeService.validateJoinCode("A1B2C3")).thenReturn(testJoinCode);
+        doNothing().when(projectParticipantService)
+            .joinProject(projectId, memberId, ProjectRole.MEMBER);
+
+        // when
+        ProjectJoinResponseDto result = projectMembershipService.joinProject(requestDto, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.projectId()).isEqualTo(projectId);
+
+        verify(projectParticipantService, times(1)).checkMemberExists(memberId);
+        verify(projectJoinCodeService, times(1)).validateJoinCode("A1B2C3");
+        verify(projectParticipantService, times(1))
+            .joinProject(projectId, memberId, ProjectRole.MEMBER);
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 실패 - 유효하지 않은 코드")
+    void joinProject_Fail_InvalidCode() {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("XXXXXX");
+
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        when(projectJoinCodeService.validateJoinCode("XXXXXX"))
+            .thenThrow(new BusinessException(ErrorCode.JOIN_CODE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.joinProject(requestDto, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.JOIN_CODE_NOT_FOUND);
+
+        verify(projectJoinCodeService, times(1)).validateJoinCode("XXXXXX");
+        verify(projectParticipantService, never()).joinProject(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("프로젝트 참여 실패 - 이미 참여 중")
+    void joinProject_Fail_AlreadyMember() {
+        // given
+        ProjectJoinRequestDto requestDto = new ProjectJoinRequestDto("A1B2C3");
+
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        when(projectJoinCodeService.validateJoinCode("A1B2C3")).thenReturn(testJoinCode);
+        doThrow(new BusinessException(ErrorCode.MEMBER_ALREADY_JOINED))
+            .when(projectParticipantService)
+            .joinProject(projectId, memberId, ProjectRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.joinProject(requestDto, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_ALREADY_JOINED);
+
+        verify(projectParticipantService, times(1))
+            .joinProject(projectId, memberId, ProjectRole.MEMBER);
+    }
+
+    @Test
+    @DisplayName("프로젝트 나가기 성공")
+    void leaveProject_Success() {
+        // given
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        doNothing().when(projectParticipantService).leaveProject(projectId, memberId);
+
+        // when
+        projectMembershipService.leaveProject(projectId, memberId);
+
+        // then
+        verify(projectParticipantService, times(1)).checkMemberExists(memberId);
+        verify(accessPolicy, times(1)).ensureProjectMember(projectId, memberId);
+        verify(projectParticipantService, times(1)).leaveProject(projectId, memberId);
+    }
+
+    @Test
+    @DisplayName("프로젝트 나가기 실패 - Owner는 나갈 수 없음")
+    void leaveProject_Fail_OwnerCannotLeave() {
+        // given
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(accessPolicy).ensureProjectMember(projectId, memberId);
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_CANNOT_LEAVE))
+            .when(projectParticipantService).leaveProject(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(() -> projectMembershipService.leaveProject(projectId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_OWNER_CANNOT_LEAVE);
+
+        verify(projectParticipantService, times(1)).leaveProject(projectId, memberId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 성공")
+    void kickMember_Success() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(projectParticipantService).checkMemberExists(targetMemberId);
+        doNothing().when(accessPolicy).ensureProjectOwner(projectId, memberId);
+        doNothing().when(projectParticipantService)
+            .kickMember(projectId, targetMemberId, memberId);
+
+        // when
+        projectMembershipService.kickMember(projectId, targetMemberId, memberId);
+
+        // then
+        verify(projectParticipantService, times(1)).checkProjectExists(projectId);
+        verify(projectParticipantService, times(1)).checkMemberExists(memberId);
+        verify(projectParticipantService, times(1)).checkMemberExists(targetMemberId);
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(projectParticipantService, times(1))
+            .kickMember(projectId, targetMemberId, memberId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - 권한 없음 (Owner 아님)")
+    void kickMember_Fail_NotOwner() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(projectParticipantService).checkMemberExists(targetMemberId);
+        doThrow(new BusinessException(ErrorCode.PROJECT_OWNER_ONLY))
+            .when(accessPolicy).ensureProjectOwner(projectId, memberId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> projectMembershipService.kickMember(projectId, targetMemberId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROJECT_OWNER_ONLY);
+
+        verify(accessPolicy, times(1)).ensureProjectOwner(projectId, memberId);
+        verify(projectParticipantService, never()).kickMember(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - 자기 자신 추방 시도")
+    void kickMember_Fail_CannotKickSelf() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(accessPolicy).ensureProjectOwner(projectId, memberId);
+        doThrow(new BusinessException(ErrorCode.CANNOT_KICK_YOURSELF))
+            .when(projectParticipantService).kickMember(projectId, memberId, memberId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> projectMembershipService.kickMember(projectId, memberId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CANNOT_KICK_YOURSELF);
+
+        verify(projectParticipantService, times(1)).kickMember(projectId, memberId, memberId);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 실패 - Owner 추방 시도")
+    void kickMember_Fail_CannotKickOwner() {
+        // given
+        doNothing().when(projectParticipantService).checkProjectExists(projectId);
+        doNothing().when(projectParticipantService).checkMemberExists(memberId);
+        doNothing().when(projectParticipantService).checkMemberExists(targetMemberId);
+        doNothing().when(accessPolicy).ensureProjectOwner(projectId, memberId);
+        doThrow(new BusinessException(ErrorCode.CANNOT_KICK_OWNER))
+            .when(projectParticipantService).kickMember(projectId, targetMemberId, memberId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> projectMembershipService.kickMember(projectId, targetMemberId, memberId))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CANNOT_KICK_OWNER);
+
+        verify(projectParticipantService, times(1))
+            .kickMember(projectId, targetMemberId, memberId);
+    }
+}
+


### PR DESCRIPTION
## PR
### 🔍 한 줄 요약
- 프로젝트 멤버십 관련 컨트롤러 및 서비스 테스트 코드를 추가하였습니다.

### ✨ 작업 내용
#### ProjectMembershipServiceTest (서비스 테스트)
- 프로젝트 참여 코드 생성 성공/실패 (프로젝트 없음, 권한 없음)
- 프로젝트 참여 코드 조회 성공/실패 (권한 없음)
- 프로젝트 참여 성공/실패 (유효하지 않은 코드, 이미 참여 중)
- 프로젝트 나가기 성공/실패 (Owner는 나갈 수 없음)
- 멤버 추방 성공/실패 (권한 없음, 자기 자신, Owner 추방 시도)
#### ProjectMembershipControllerTest (컨트롤러 테스트)
- POST /api/projects/{projectId}/join-code (성공, 404, 403)
- GET /api/projects/{projectId}/join-code (성공, 403)
- POST /api/projects/join (성공, Validation 에러, 404, 409)
- DELETE /api/projects/{projectId}/leave (성공, 403)
- DELETE /api/projects/{projectId}/members/{targetMemberId} (성공, 403, 400)

### #️⃣ 연관 이슈
- Close #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 프로젝트 멤버십 관련 컨트롤러 및 서비스에 대한 포괄적인 단위 테스트 스위트 추가

---

**참고:** 이번 변경 사항은 내부 테스트 개선으로 사용자에게 직접 영향을 미치지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->